### PR TITLE
Adding a Dns Helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Github action for connecting to OpenVPN server.
 | Name | Description | Required |
 | --- | --- | --- | 
 | `config_file` | Location of OpenVPN client config file | yes |
+| `dnshelper_script_file` | Location of Dns helper script file | Optional |
 
 ### Authentication Inputs
 
@@ -23,12 +24,18 @@ Supported authentication methods:
 | `client_key` | Local peer's private key | Client certificate auth |
 | `tls_auth_key` | Pre-shared secret for TLS-auth HMAC signature | Optional |
 
+
 All authentication inputs should be provided by encrypted secrets environment variables.
 
 ## Usage 
 
 - Create client configuration file based on the [official sample](https://github.com/OpenVPN/openvpn/blob/master/sample/sample-config-files/client.conf).
   It is recommended to use inline certificates to include them directly in configuration file like [this](https://github.com/kota65535/github-openvpn-connect-action/tree/master/.github/workflows/client.ovpn).
+
+- If you need Dns resolution in your vpn, ubuntu vpn client is bad at dns option triggering, it's possible to use an helper
+script in this case, for exemple [this one](https://github.com/jonathanio/update-systemd-resolved)
+If you use it, warning, this file must be defined as executable in your repo (chmod +x).
+
 - Usage in your workflow is like following:
 ```yaml
       - name: Checkout
@@ -39,6 +46,7 @@ All authentication inputs should be provided by encrypted secrets environment va
         uses: "kota65535/github-openvpn-connect-action@v1"
         with:
           config_file: ./github/workflows/client.ovpn
+          dnshelper_script_file: ./github/workflows/update-systemd-resolved
           username: ${{ secrets.OVPN_USERNAME }}
           password: ${{ secrets.OVPN_PASSWORD }}
           client_key: ${{ secrets.OVPN_CLIENT_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   client_key:
     description: "Local peer's private key"
     required: false
+  dnshelper_script_file:
+    description: "Location of dns changer script path (executable)"
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -798,6 +798,7 @@ const run = () => {
   const password = core.getInput('password').trim()
   const clientKey = core.getInput('client_key').trim()
   const tlsAuthKey = core.getInput('tls_auth_key').trim()
+  const dnsHelperScriptFile = core.getInput('dnshelper_script_file').trim()
 
   if (!fs.existsSync(configFile)) {
     throw new Error(`config file '${configFile}' not found`)
@@ -819,6 +820,19 @@ const run = () => {
     fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('client.key', clientKey)
     fs.writeFileSync('ta.key', tlsAuthKey)
+  }
+
+  // client dsn Script Path
+  if (dnsHelperScriptFile.length > 0) {
+    if (!fs.existsSync(dnsHelperScriptFile)) {
+      throw new Error(`dns helper script file '${dnsHelperScriptFile}' not found`)
+    }
+    const githubWorkspacePath = process.env.GITHUB_WORKSPACE
+
+    fs.appendFileSync(configFile, 'script-security 2\n')
+    fs.appendFileSync(configFile, `up ${githubWorkspacePath}/${dnsHelperScriptFile}\n`)
+    fs.appendFileSync(configFile, `down ${githubWorkspacePath}/${dnsHelperScriptFile}\n`)
+    fs.appendFileSync(configFile, 'down-pre\n')
   }
 
   core.info('========== begin configuration ==========')

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kota65535/github-openvpn-connect-action.git"
+    "url": "git+https://github.com/eliberty/github-openvpn-connect-action.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/kota65535/github-openvpn-connect-action/issues"
+    "url": "https://github.com/eliberty/github-openvpn-connect-action/issues"
   },
-  "homepage": "https://github.com/kota65535/github-openvpn-connect-action#readme",
+  "homepage": "https://github.com/eliberty/github-openvpn-connect-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eliberty/github-openvpn-connect-action.git"
+    "url": "git+https://github.com/kota65535/github-openvpn-connect-action.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/eliberty/github-openvpn-connect-action/issues"
+    "url": "https://github.com/kota65535/github-openvpn-connect-action/issues"
   },
-  "homepage": "https://github.com/eliberty/github-openvpn-connect-action#readme",
+  "homepage": "https://github.com/kota65535/github-openvpn-connect-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ const run = () => {
   const password = core.getInput('password').trim()
   const clientKey = core.getInput('client_key').trim()
   const tlsAuthKey = core.getInput('tls_auth_key').trim()
+  const dnsHelperScriptFile = core.getInput('dnshelper_script_file').trim()
 
   if (!fs.existsSync(configFile)) {
     throw new Error(`config file '${configFile}' not found`)
@@ -30,6 +31,19 @@ const run = () => {
     fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('client.key', clientKey)
     fs.writeFileSync('ta.key', tlsAuthKey)
+  }
+
+  // client dsn Script Path
+  if (dnsHelperScriptFile.length > 0) {
+    if (!fs.existsSync(dnsHelperScriptFile)) {
+      throw new Error(`dns helper script file '${dnsHelperScriptFile}' not found`)
+    }
+    const githubWorkspacePath = process.env.GITHUB_WORKSPACE
+
+    fs.appendFileSync(configFile, 'script-security 2\n')
+    fs.appendFileSync(configFile, `up ${githubWorkspacePath}/${dnsHelperScriptFile}\n`)
+    fs.appendFileSync(configFile, `down ${githubWorkspacePath}/${dnsHelperScriptFile}\n`)
+    fs.appendFileSync(configFile, 'down-pre\n')
   }
 
   core.info('========== begin configuration ==========')


### PR DESCRIPTION
Hi, 
This PR add an option to provide a dns helper script usually needed to have a clean dns resolution on ubuntu clients. 

A good dns helper script his https://github.com/jonathanio/update-systemd-resolved
and i've successfully used it with your action.
The important thing is that the script have to be executable.

Please tell me if it's something interesting in your opinion. 
I've already forked and modified this action, but i felt like this is a useful addition.

Xavier

