### PR TITLE
Only use tls auth key when it is given

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -816,8 +816,11 @@ const run = () => {
   // client certificate auth
   if (clientKey) {
     fs.appendFileSync(configFile, 'key client.key\n')
-    fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('client.key', clientKey)
+  }
+
+  if (tlsAuthKey) {
+    fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('ta.key', tlsAuthKey)
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -27,8 +27,11 @@ const run = () => {
   // client certificate auth
   if (clientKey) {
     fs.appendFileSync(configFile, 'key client.key\n')
-    fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('client.key', clientKey)
+  }
+
+  if (tlsAuthKey) {
+    fs.appendFileSync(configFile, 'tls-auth ta.key 1\n')
     fs.writeFileSync('ta.key', tlsAuthKey)
   }
 


### PR DESCRIPTION
When specifying a client key to use, this github action automatically assumes that a tls auth key is also given. We are not using tls auth key but are using a client key so we couldn't use this action.

This PR fixes the problem by only inserting the tls auth key when it is actually specified. 

Let me know what you think. I could not reproduce the `dist/index.js` file by running `npm run build`. It gave me something completely different that didn't work. So I edited the index file by hand, please check by rerunning on your machine.
