### PR TITLE
Arguments passed to tls_crypt_v2_key were failing when using OpenVPN > 2.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "OpenVPN-Connect"
+name: "OpenVPN-Connect RoninSTi"
 description: "connect to OpenVPN server"
 branding:
   icon: "lock"

--- a/dist/index.js
+++ b/dist/index.js
@@ -25228,7 +25228,7 @@ const run = (callback) => {
   }
 
   if (tlsCryptV2Key) {
-    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key 1\n");
+    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key\n");
     fs.writeFileSync("tcv2.key", tlsCryptV2Key, { mode: 0o600 });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ const run = (callback) => {
   }
 
   if (tlsCryptV2Key) {
-    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key");
+    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key\n");
     fs.writeFileSync("tcv2.key", tlsCryptV2Key, { mode: 0o600 });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ const run = (callback) => {
   }
 
   if (tlsCryptV2Key) {
-    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key 1\n");
+    fs.appendFileSync(configFile, "tls-crypt-v2 tcv2.key");
     fs.writeFileSync("tcv2.key", tlsCryptV2Key, { mode: 0o600 });
   }
 


### PR DESCRIPTION
OpenVPN 2.6 was failing with the existing action, the `1` argument being passed was causing the failure. I just fixed the issue in a fork for our immediate needs. I wanted to use this PR to maybe open a discussion of the real solution to correct this. 